### PR TITLE
riscv: clone() crash fixes

### DIFF
--- a/linux-user/riscv/target_cpu.h
+++ b/linux-user/riscv/target_cpu.h
@@ -6,12 +6,12 @@ static inline void cpu_clone_regs(CPURISCVState *env, target_ulong newsp)
     if (newsp)
         env->gpr[xSP] = newsp;
 
-    /* stub */
+    env->gpr[xA0] = 0;
 }
 
 static inline void cpu_set_tls(CPURISCVState *env, target_ulong newtls)
 {
-    /* stub */
+    env->gpr[xTP] = newtls;
 }
 
 #endif


### PR DESCRIPTION
Needs to set the TLS pointer and return 0 in the child.

With this change it no longer crashes on running "git grep".  The "make" crash turns out to be unrelated.
