### PR TITLE
riscv: statfs ABI; fixes #6

### DIFF
--- a/linux-user/syscall_defs.h
+++ b/linux-user/syscall_defs.h
@@ -2029,7 +2029,7 @@ struct target_statfs64 {
 	uint32_t	f_spare[6];
 };
 #elif (defined(TARGET_PPC64) || defined(TARGET_X86_64) || \
-       defined(TARGET_SPARC64) || defined(TARGET_AARCH64)) && \
+       defined(TARGET_SPARC64) || defined(TARGET_AARCH64) || defined(TARGET_RISCV)) && \
        !defined(TARGET_ABI32)
 struct target_statfs {
 	abi_long f_type;


### PR DESCRIPTION
With this change `df` works in the container
