### PR TITLE
riscv: add XLEN to uname -m

### DIFF
--- a/linux-user/riscv/target_syscall.h
+++ b/linux-user/riscv/target_syscall.h
@@ -38,7 +38,11 @@ struct target_pt_regs {
 	abi_long t6;
 };
 
-#define UNAME_MACHINE "riscv"
+#ifdef TARGET_RISCV32
+#define UNAME_MACHINE "riscv32"
+#else
+#define UNAME_MACHINE "riscv64"
+#endif
 #define UNAME_MINIMUM_RELEASE "3.8.0"
 
 #define TARGET_MINSIGSTKSZ 2048


### PR DESCRIPTION
Apparently rpm expects this and both the Fedora and Gentoo efforts are
floating kernel patches to use riscv64/riscv32 instead of riscv.

cc riscv/riscv-linux#17

---

(I don't actually have anything that depends on this yet)
