### PR TITLE
Misc ABI fixes

### DIFF
--- a/linux-user/signal.c
+++ b/linux-user/signal.c
@@ -5913,9 +5913,9 @@ static void setup_rt_frame(int sig, struct target_sigaction *ka,
 
     env->pc = ka->_sa_handler;
     env->gpr[xSP] = frame_addr;
-    env->gpr[xA1] = sig;
-    env->gpr[xA2] = frame_addr + offsetof(struct target_rt_sigframe, info);
-    env->gpr[xA3] = frame_addr + offsetof(struct target_rt_sigframe, uc);
+    env->gpr[xA0] = sig;
+    env->gpr[xA1] = frame_addr + offsetof(struct target_rt_sigframe, info);
+    env->gpr[xA2] = frame_addr + offsetof(struct target_rt_sigframe, uc);
     env->gpr[xRA] = frame_addr + offsetof(struct target_rt_sigframe, tramp);
 
     return;

--- a/linux-user/syscall_defs.h
+++ b/linux-user/syscall_defs.h
@@ -1947,6 +1947,7 @@ struct target_stat {
     unsigned int __unused5;
 };
 
+#if !defined(TARGET_RISCV64)
 #define TARGET_HAS_STRUCT_STAT64
 struct target_stat64 {
     uint64_t st_dev;
@@ -1970,6 +1971,7 @@ struct target_stat64 {
     unsigned int __unused4;
     unsigned int __unused5;
 };
+#endif
 
 #else
 #error unsupported CPU

--- a/target-riscv/translate_rvf.c
+++ b/target-riscv/translate_rvf.c
@@ -295,7 +295,7 @@ static void gen_opfp(DC, uint32_t insn)
         case /* 0000100 */ 0x04: gen_helper_fsub_s(fd, ep, f1, f2, vm); break;
         case /* 0001000 */ 0x08: gen_helper_fmul_s(fd, ep, f1, f2, vm); break;
         case /* 0001100 */ 0x0C: gen_helper_fdiv_s(fd, ep, f1, f2, vm); break;
-        case /* 0101100 */ 0x2C: gen_helper_fsqrt_s(fd, ep, f2, vm); break;
+        case /* 0101100 */ 0x2C: gen_helper_fsqrt_s(fd, ep, f1, vm); break;
         case /* 0010000 */ 0x10: gen_fsgnj(dc, fd, f1, f2, rm, 32); break;
         case /* 0010100 */ 0x14: gen_fminmax_s(dc, fd, ep, f1, f2, rm); break;
         case /* 1010000 */ 0x50: gen_fcmp_s(dc, vd, ep, f1, f2, rm); break;
@@ -304,7 +304,7 @@ static void gen_opfp(DC, uint32_t insn)
         case /* 0000101 */ 0x05: gen_helper_fsub_d(fd, ep, f1, f2, vm); break;
         case /* 0001001 */ 0x09: gen_helper_fmul_d(fd, ep, f1, f2, vm); break;
         case /* 0001101 */ 0x0D: gen_helper_fdiv_d(fd, ep, f1, f2, vm); break;
-        case /* 0101101 */ 0x2D: gen_helper_fsqrt_d(fd, ep, f2, vm); break;
+        case /* 0101101 */ 0x2D: gen_helper_fsqrt_d(fd, ep, f1, vm); break;
         case /* 0010001 */ 0x11: gen_fsgnj(dc, fd, f1, f2, rm, 64); break;
         case /* 0010101 */ 0x15: gen_fminmax_d(dc, fd, ep, f1, f2, rm); break;
         case /* 1010001 */ 0x51: gen_fcmp_d(dc, vd, ep, f1, f2, rm); break;


### PR DESCRIPTION
With these I can run a rpm build of gforth until the middle of the test suite, whereupon we hit the upstream qemu bug which is fixed by qemu/qemu@655ed67c.

Next I'll try updating to the latest upstream qemu, or at least to the released 2.7.0, might need help.
